### PR TITLE
Enhancements for Expo Go Compatibility and Type Corrections in Karte SDK for React-Native

### DIFF
--- a/example/src/components/Core.tsx
+++ b/example/src/components/Core.tsx
@@ -111,7 +111,7 @@ export function CoreComponent() {
     ]);
   };
   const userSyncScript = () => {
-    const script = UserSync.getUserSyncScript();
+    const script = UserSync.getUserSyncScript() ?? '';
     Alert.alert('User sync script', script, [
       {
         text: 'OK',

--- a/example/src/components/WebView.tsx
+++ b/example/src/components/WebView.tsx
@@ -5,7 +5,7 @@ import { UserSync } from '@react-native-karte/core';
 
 export function WebViewComponent() {
   const api_key = 'your_api_key';
-  const script = UserSync.getUserSyncScript();
+  const script = UserSync.getUserSyncScript() ?? '';
   return (
     <View style={{ flex: 1 }}>
       <WebView

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -18,7 +18,8 @@ import { NativeModules } from 'react-native';
 import { normalize } from '@react-native-karte/utilities';
 import type { KRTCoreNativeModule } from './types';
 
-const nativeModule: KRTCoreNativeModule = NativeModules.RNKRTCoreModule;
+const nativeModule: KRTCoreNativeModule | undefined =
+  NativeModules.RNKRTCoreModule;
 
 /** KARTE SDKのエントリポイントクラスです。 */
 export class KarteApp {
@@ -32,7 +33,7 @@ export class KarteApp {
    * なお初期化が行われていない場合は空文字列を返します。
    */
   public static get visitorId(): string {
-    return nativeModule.getVisitorId();
+    return nativeModule?.getVisitorId() ?? '';
   }
 
   /**
@@ -44,7 +45,7 @@ export class KarteApp {
    * また初期化が行われていない場合は `false` を返します。
    */
   public static get isOptOut(): boolean {
-    return nativeModule.isOptOut();
+    return nativeModule?.isOptOut() ?? false;
   }
 
   /**
@@ -54,7 +55,7 @@ export class KarteApp {
    * 初期化が行われていない状態で呼び出した場合はオプトインは行われません。
    */
   public static optIn(): void {
-    nativeModule.optIn();
+    nativeModule?.optIn();
   }
 
   /**
@@ -64,7 +65,7 @@ export class KarteApp {
    * 初期化が行われていない状態で呼び出した場合はオプトアウトは行われません。
    */
   public static optOut(): void {
-    nativeModule.optOut();
+    nativeModule?.optOut();
   }
 
   /**
@@ -77,7 +78,7 @@ export class KarteApp {
    * なお初期化が行われていない状態で呼び出した場合は再生成は行われません。
    */
   public static renewVisitorId(): void {
-    nativeModule.renewVisitorId();
+    nativeModule?.renewVisitorId();
   }
 }
 
@@ -91,7 +92,7 @@ export class Tracker {
    */
 
   public static track(name: string, values: object = {}) {
-    nativeModule.track(name, normalize(values));
+    nativeModule?.track(name, normalize(values));
   }
 
   /**
@@ -110,9 +111,9 @@ export class Tracker {
 
   public static identify(value: string | object, values?: object): void {
     if (typeof value === 'string') {
-      nativeModule.identifyWithUserId(value, normalize(values ?? {}));
+      nativeModule?.identifyWithUserId(value, normalize(values ?? {}));
     } else {
-      nativeModule.identify(normalize(value));
+      nativeModule?.identify(normalize(value));
     }
   }
 
@@ -122,7 +123,7 @@ export class Tracker {
    * @param values Attributeイベントに紐付けるカスタムオブジェクト
    */
   public static attribute(values: object) {
-    nativeModule.attribute(normalize(values));
+    nativeModule?.attribute(normalize(values));
   }
 
   /**
@@ -132,7 +133,7 @@ export class Tracker {
    * @param values Viewイベントに紐付けるカスタムオブジェクト
    */
   public static view(viewName: string, title?: string, values: object = {}) {
-    nativeModule.view(viewName, title, normalize(values));
+    nativeModule?.view(viewName, title, normalize(values));
   }
 }
 /**
@@ -156,7 +157,7 @@ export class UserSync {
    * @param url 連携するページのURL文字列
    */
   public static appendingQueryParameter(url: string): string {
-    return nativeModule.appendingUserSyncQueryParameter(url);
+    return nativeModule?.appendingUserSyncQueryParameter(url) ?? url;
   }
 
   /**
@@ -166,8 +167,8 @@ export class UserSync {
    * ユーザースクリプトとしてWebViewに設定することで、WebView内のタグと連携されます。
    * なおSDKの初期化が行われていない場合はnullを返却します。
    */
-  public static getUserSyncScript(): string {
-    return nativeModule.getUserSyncScript();
+  public static getUserSyncScript(): string | null {
+    return nativeModule?.getUserSyncScript() ?? null;
   }
 }
 

--- a/packages/in-app-messaging/src/index.tsx
+++ b/packages/in-app-messaging/src/index.tsx
@@ -17,7 +17,7 @@
 import { NativeModules } from 'react-native';
 import type { KRTInAppMessagingNativeModule } from './types';
 
-const nativeModule: KRTInAppMessagingNativeModule =
+const nativeModule: KRTInAppMessagingNativeModule | undefined =
   NativeModules.RNKRTInAppMessagingModule;
 
 /** アプリ内メッセージの管理を行うクラスです。 */
@@ -30,11 +30,11 @@ export class InAppMessaging {
    * アプリ内メッセージが表示中の場合は true を返し、表示されていない場合は false を返します。
    */
   public static get isPresenting(): boolean {
-    return nativeModule.isPresenting();
+    return nativeModule?.isPresenting() ?? false;
   }
   /** 現在表示中の全てのアプリ内メッセージを非表示にします。 */
   public static dismiss(): void {
-    nativeModule.dismiss();
+    nativeModule?.dismiss();
   }
 
   /**
@@ -44,11 +44,11 @@ export class InAppMessaging {
    * なお既に表示されているアプリ内メッセージは、メソッドの呼び出しと同時に非表示となります。
    */
   public static suppress(): void {
-    nativeModule.suppress();
+    nativeModule?.suppress();
   }
 
   /** アプリ内メッセージの表示抑制状態を解除します。 */
   public static unsuppress(): void {
-    nativeModule.unsuppress();
+    nativeModule?.unsuppress();
   }
 }

--- a/packages/notification/src/index.tsx
+++ b/packages/notification/src/index.tsx
@@ -17,7 +17,7 @@
 import { NativeModules } from 'react-native';
 import type { KRTNotificationNativeModule, RemoteMessage } from './types';
 
-const nativeModule: KRTNotificationNativeModule =
+const nativeModule: KRTNotificationNativeModule | undefined =
   NativeModules.RNKRTNotificationModule;
 
 /** リモート通知メッセージのパースおよびメッセージ中に含まれるディープリンクのハンドリングを行うためのクラスです。 */
@@ -32,7 +32,7 @@ export class Notification {
    * @param fcmToken FCMトークン
    */
   public static registerFCMToken(fcmToken?: string): void {
-    nativeModule.registerFCMToken(fcmToken);
+    nativeModule?.registerFCMToken(fcmToken);
   }
 
   /**
@@ -44,7 +44,7 @@ export class Notification {
    * @param remoteMessage リモート通知メッセージ
    */
   public static create(remoteMessage: RemoteMessage): Notification | null {
-    if (nativeModule.canHandle(remoteMessage.data ?? {})) {
+    if (nativeModule?.canHandle(remoteMessage.data ?? {})) {
       return new Notification(remoteMessage);
     } else {
       return null;
@@ -59,16 +59,17 @@ export class Notification {
    * - KARTE以外から送信されたメッセージ
    * - メッセージ中に URL が含まれていない場合
    * - 不正なURL
+   * - NativeModules.RNKRTNotificationModule が存在しない場合(expo go 使用時を想定)
    */
   public get url(): string | null {
-    return nativeModule.retrieveURL(this.remoteMessage.data ?? {});
+    return nativeModule?.retrieveURL(this.remoteMessage.data ?? {}) ?? null;
   }
 
   /**
    * (Androidのみ) KARTE経由で送信された通知メッセージから、通知を作成・表示します。
    */
   public show(): void {
-    return nativeModule.show(this.remoteMessage.data ?? {});
+    return nativeModule?.show(this.remoteMessage.data ?? {});
   }
 
   /**
@@ -77,9 +78,10 @@ export class Notification {
    * @remarks
    * 内部では、メッセージ中に含まれるURLを `UIApplication.open(_:options:completionHandler:)` に渡す処理を行っています。
    * `UIApplication.open(_:options:completionHandler:)`の呼び出しが行われた場合は true を返し、メッセージ中にURLが含まれない場合は false を返します。
+   * NativeModules.RNKRTNotificationModule が存在しない場合(expo go 使用時を想定)
    */
   public handle(): boolean {
-    return nativeModule.handle(this.remoteMessage.data ?? {});
+    return nativeModule?.handle(this.remoteMessage.data ?? {}) ?? false;
   }
 
   /**
@@ -89,6 +91,6 @@ export class Notification {
    * 通常は自動でクリック計測が行われるため本メソッドを呼び出す必要はありませんが、 `isEnabledAutoMeasurement` が false の場合は自動での計測が行われないため、 本メソッドを呼び出す必要があります。
    */
   public track(): void {
-    nativeModule.track(this.remoteMessage.data ?? {});
+    nativeModule?.track(this.remoteMessage.data ?? {});
   }
 }


### PR DESCRIPTION
Thank you for crafting the karte SDK for react-native.

## Overview
- Modified for compatibility with Expo Go.
- Corrected some misconfigured return types.

### Details
It was observed that when using Expo Go, `NativeModules.RNKRTXXXModule` becomes undefined. To accommodate for this, I've introduced `undefined` as a union type and employed optional chaining to ensure that API calls are made safely and correctly within the Expo Go environment.

## Additional Notes
- Confirmed that `yarn tsc --noEmit` runs without issues.
- Ensured that `yarn test` executes successfully.
- Verified that `yarn build` operates correctly.
- Created an internal package using `yarn build && npm pack` and validated its functionality within my project.